### PR TITLE
Add option to sync all seasons

### DIFF
--- a/web/forms.py
+++ b/web/forms.py
@@ -3,7 +3,7 @@ Forms for the NHL MySQL Sync web interface.
 """
 
 from flask_wtf import FlaskForm
-from wtforms import StringField, PasswordField, IntegerField, SelectField, SubmitField
+from wtforms import StringField, PasswordField, IntegerField, SelectField, SubmitField, BooleanField
 from wtforms.validators import DataRequired, NumberRange, Optional
 
 class ConfigForm(FlaskForm):
@@ -45,5 +45,7 @@ class SyncForm(FlaskForm):
                            validators=[DataRequired()])
     
     season = StringField('Season (YYYYYYYY format, e.g., 20222023)', validators=[Optional()])
+    
+    all_seasons = BooleanField('Sync All Seasons (from 2010-2011 to present)')
     
     submit = SubmitField('Start Synchronization')


### PR DESCRIPTION
This PR adds a new feature to sync all NHL seasons from 2010-2011 to present.

Changes include:
- Added "Sync All Seasons" checkbox to the sync form
- Modified the sync logic to handle multiple seasons when the checkbox is selected
- Added progress tracking for each season
- Added ability to cancel sync between seasons
- Added JavaScript to disable the season input when "All Seasons" is checked

This feature allows users to easily sync data for all NHL seasons with a single click, rather than having to run multiple sync operations manually.